### PR TITLE
Add prompt support

### DIFF
--- a/src/GPT2/prompts/test1_4samples.txt
+++ b/src/GPT2/prompts/test1_4samples.txt
@@ -1,0 +1,7 @@
+Here is a recipe for real Neapolitan margherita pizza:
+
+The 10 most famous jazz albums of all times are:
+
+Here are the top attractions you can't miss when visiting Chicago:
+
+Here is a piece of code to read the lines of a text file using Python:

--- a/src/GPT2/starter.py
+++ b/src/GPT2/starter.py
@@ -61,7 +61,7 @@ parser.add_argument(
 parser.add_argument(
     "--prompt",
     type=str,
-    default="\n",
+    default=None,
     help="""(Optional) prompt string or 'FILE:<path_to_file.txt>' indicating a file where each
     paragraph is a prompt""",
 )

--- a/src/GPT2/starter.py
+++ b/src/GPT2/starter.py
@@ -59,6 +59,13 @@ parser.add_argument(
     help="Produce plots and store the points as csv files ('/logs/tok_per_time' folder)",
 )
 parser.add_argument(
+    "--prompt",
+    type=str,
+    default="\n",
+    help="""(Optional) prompt string or 'FILE:<path_to_file.txt>' indicating a file where each
+    paragraph is a prompt""",
+)
+parser.add_argument(
     "--n-samples",
     type=int,
     default=3,
@@ -144,7 +151,9 @@ if __name__ == "__main__":
     # Operation
     try:
         gen_samples, gen_time = gpt_distr.start(
-            n_samples=args.n_samples, tokens_per_sample=tok_per_sample
+            n_samples=args.n_samples,
+            tokens_per_sample=tok_per_sample,
+            prompt=args.prompt,
         )
     except KeyboardInterrupt:
         cp.engine.stop()

--- a/src/GPT2/sub/config.py
+++ b/src/GPT2/sub/config.py
@@ -73,7 +73,7 @@ TOP_K = (
     200  # retain only the top_k most likely tokens, clamp others to have 0 probability
 )
 TEMPERATURE = (
-    0.8  # 1.0 = no change, < 1.0 = less random, > 1.0 = more random, in predictions
+    1  # 1.0 = no change, < 1.0 = less random, > 1.0 = more random, in predictions
 )
 
 # ---- MDI settings ------------------------------

--- a/src/GPT2/sub/config.py
+++ b/src/GPT2/sub/config.py
@@ -73,7 +73,7 @@ TOP_K = (
     200  # retain only the top_k most likely tokens, clamp others to have 0 probability
 )
 TEMPERATURE = (
-    1  # 1.0 = no change, < 1.0 = less random, > 1.0 = more random, in predictions
+    0.8  # 1.0 = no change, < 1.0 = less random, > 1.0 = more random, in predictions
 )
 
 # ---- MDI settings ------------------------------

--- a/src/GPT2/sub/model_dist.py
+++ b/src/GPT2/sub/model_dist.py
@@ -484,7 +484,7 @@ class GPTServer:
                 )
             logger_wp.info("Starting generation loop")
 
-            out_text, gen_time = self._starter_loop(max_new_tokens, n_samples, prompt)
+            out_text, gen_time = self._starter_loop(n_samples, max_new_tokens, prompt)
 
             return out_text, gen_time
         else:

--- a/src/GPT2/sub/model_dist.py
+++ b/src/GPT2/sub/model_dist.py
@@ -795,11 +795,12 @@ class GPTServer:
 
         if n_samples is None:
             n_samples = self.n_nodes
+        elif n_samples < 1:
+            raise ValueError("Cannot generate less than 1 sample!")
         elif n_samples < self.n_nodes:
             warnings.warn(
-                f"Cannot generate less samples than nodes! Overriding n_samples = {self.n_nodes}"
+                f"Generating less samples {n_samples} than nodes ({self.n_nodes}) will not be efficient!"
             )
-            n_samples = self.n_nodes
 
         if "cuda" in self.device:
             device_type = "cuda"

--- a/src/GPT2/sub/model_dist.py
+++ b/src/GPT2/sub/model_dist.py
@@ -832,9 +832,6 @@ class GPTServer:
             for start_txt in start_ids
         ]
 
-        if VERB:
-            print(f"Starting generation - {n_samples} samples, {max_new_tokens} tokens")
-
         self.model.eval()
         start_time = time.time()
         if PLOTS:

--- a/src/GPT2/sub/model_dist.py
+++ b/src/GPT2/sub/model_dist.py
@@ -822,7 +822,7 @@ class GPTServer:
         if prompt is None:
             start = ["\n"] * n_samples
         else:
-            start = get_prompt(prompt, n_samples)
+            start = get_prompt(prompt, n_samples, verb=VERB)
 
         assert len(start) == n_samples
 

--- a/src/GPT2/sub/model_dist.py
+++ b/src/GPT2/sub/model_dist.py
@@ -824,11 +824,16 @@ class GPTServer:
         else:
             start = get_prompt(prompt, n_samples)
 
+        assert len(start) == n_samples
+
         start_ids = [self.tok_encode(txt) for txt in start]
         idx = [
             torch.tensor(start_txt, dtype=torch.long, device=self.device)[None, ...]
             for start_txt in start_ids
         ]
+
+        if VERB:
+            print(f"Starting generation - {n_samples} samples, {max_new_tokens} tokens")
 
         self.model.eval()
         start_time = time.time()

--- a/src/GPT2/sub/model_dist.py
+++ b/src/GPT2/sub/model_dist.py
@@ -416,6 +416,7 @@ class GPTServer:
         self,
         n_samples: Union[None, int] = None,
         max_new_tokens: Union[None, int] = None,
+        prompt: Union[None, str] = None,
     ) -> Union[None, Tuple[List[str], float]]:
         """
         Perform normal operation (open sockets, wait for communication from previous
@@ -438,6 +439,8 @@ class GPTServer:
                 text)
             max_new_tokens: ONLY FOR STARTER - maximum number of tokens per generated
                 sample
+            prompt: (STARTER ONLY) - string containing the prompt or
+                "FILE:<filename.txt>"
 
         Returns:
             if starter node, return the list of produced samples, else nothing
@@ -481,7 +484,7 @@ class GPTServer:
                 )
             logger_wp.info("Starting generation loop")
 
-            out_text, gen_time = self._starter_loop(max_new_tokens, n_samples)
+            out_text, gen_time = self._starter_loop(max_new_tokens, n_samples, prompt)
 
             return out_text, gen_time
         else:
@@ -1464,7 +1467,9 @@ class GPTDistributed:
             return 1
         return 0
 
-    def start(self, n_samples: int, tokens_per_sample: int) -> Tuple[List[str], float]:
+    def start(
+        self, n_samples: int, tokens_per_sample: int, prompt: Union[None, str] = None
+    ) -> Tuple[List[str], float]:
         """
         Start the operation - webserver + model
 
@@ -1477,6 +1482,9 @@ class GPTDistributed:
             n_samples: number of samples to be generated
             tokens_per_sample: number of generated tokens per sample; the number
                 of samples is the same as the number of nodes
+            prompt (optional): either a string consisting of the user prompt, or a
+                string with the format "FILE:<prompt.txt>" pointing to a file containing
+                a prompt in each paragraph
 
         Returns:
             List of produced samples
@@ -1488,7 +1496,7 @@ class GPTDistributed:
 
         # The code below assumes we will receive the correct info (not None)
         out, time_gen = self.webserv.start(
-            n_samples=n_samples, max_new_tokens=tokens_per_sample
+            n_samples=n_samples, max_new_tokens=tokens_per_sample, prompt=prompt
         )
 
         print("-------------------------------------------------")

--- a/src/GPT2/sub/utils.py
+++ b/src/GPT2/sub/utils.py
@@ -496,6 +496,10 @@ def get_prompt(prompt: str, n_samples: int = 1) -> List[str]:
     """
 
     if prompt.startswith("FILE:"):
+        if not all([prompt.endswith(ext) for ext in (".txt", ".md")]):
+            raise ValueError(
+                f"Unsupported file type for {prompt}\nSupported types are: '.txt', '.md'"
+            )
         print("Reading prompt(s) from file")
         fname = prompt[5:]
         out = []

--- a/src/GPT2/sub/utils.py
+++ b/src/GPT2/sub/utils.py
@@ -475,7 +475,7 @@ def load_from_hf(model_type: str) -> Tuple[Dict[str, Any], Dict[str, Any]]:
 # ---------- PROMPT -------------------------------------------------------------------
 
 
-def get_prompt(prompt: str, n_samples: int = 1) -> List[str]:
+def get_prompt(prompt: str, n_samples: int = 1, **kwargs) -> List[str]:
     """
     Extract the user prompt.
 
@@ -494,6 +494,7 @@ def get_prompt(prompt: str, n_samples: int = 1) -> List[str]:
     considered.
     If the file contains too few, instead, the output list will be padded with "\\n"
     """
+    verb = kwargs.get("verb", False)
 
     if prompt.startswith("FILE:"):
         if not any([prompt.endswith(ext) for ext in (".txt", ".md")]):
@@ -523,7 +524,8 @@ def get_prompt(prompt: str, n_samples: int = 1) -> List[str]:
 
         assert len(out) == n_samples
 
-        print(out)
+        if verb:
+            print(out)
         return out
     else:
         return [prompt] * n_samples

--- a/src/GPT2/sub/utils.py
+++ b/src/GPT2/sub/utils.py
@@ -523,9 +523,12 @@ def get_prompt(prompt: str, n_samples: int = 1) -> List[str]:
 
         assert len(out) == n_samples
 
+        print(out)
         return out
     else:
-        return [prompt] * n_samples
+        out = [prompt] * n_samples
+        print(out)
+        return out
 
 
 # ---------- PLOTS --------------------------------------------------------------------

--- a/src/GPT2/sub/utils.py
+++ b/src/GPT2/sub/utils.py
@@ -496,7 +496,7 @@ def get_prompt(prompt: str, n_samples: int = 1) -> List[str]:
     """
 
     if prompt.startswith("FILE:"):
-        if not all([prompt.endswith(ext) for ext in (".txt", ".md")]):
+        if not any([prompt.endswith(ext) for ext in (".txt", ".md")]):
             raise ValueError(
                 f"Unsupported file type for {prompt}\nSupported types are: '.txt', '.md'"
             )

--- a/src/GPT2/sub/utils.py
+++ b/src/GPT2/sub/utils.py
@@ -523,12 +523,9 @@ def get_prompt(prompt: str, n_samples: int = 1) -> List[str]:
 
         assert len(out) == n_samples
 
-        print(out)
         return out
     else:
-        out = [prompt] * n_samples
-        print(out)
-        return out
+        return [prompt] * n_samples
 
 
 # ---------- PLOTS --------------------------------------------------------------------

--- a/src/GPT2/sub/utils.py
+++ b/src/GPT2/sub/utils.py
@@ -523,6 +523,7 @@ def get_prompt(prompt: str, n_samples: int = 1) -> List[str]:
 
         assert len(out) == n_samples
 
+        print(out)
         return out
     else:
         return [prompt] * n_samples


### PR DESCRIPTION
Tested - successful. Closes #12 

Prompt can be provided either:
- As a string (`--prompt "Here is the recipe for pizza: "`); the same prompt will be used for all samples
- As a file - each paragraph will be a separate prompt for a different sample. Notice that the `\n` is kept.

Also allows to generate of fewer samples than n. of nodes, and raise a warning in this case.